### PR TITLE
Fixed a bug an linter error in About Page

### DIFF
--- a/src/router/routes/About/About.jsx
+++ b/src/router/routes/About/About.jsx
@@ -1,10 +1,10 @@
 import Box from "@mui/material/Box";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 
 import Md3Typography from "../../../components/md3/Md3Typography/Md3Typography";
 
 export default function About() {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   return (
     <Box>
@@ -17,24 +17,13 @@ export default function About() {
           p: 1,
         }}
       >
-        <Md3Typography role="display">Sextant</Md3Typography>
+        <Md3Typography role="display">SPhoG</Md3Typography>
         <Md3Typography role="body">
           {process.env.REACT_APP_VERSION}
         </Md3Typography>
         <Md3Typography role="body">
-          <a href="https://github.com/derickkemp/sextant">
-            https://github.com/derickkemp/sextant
-          </a>
-        </Md3Typography>
-        <Md3Typography role="title" sx={{ mt: 1, width: "100%" }}>
-          Attributions
-        </Md3Typography>
-        <Md3Typography role="body" sx={{ width: "100%" }}>
-          <a
-            href="https://www.flaticon.com/free-icons/sextant"
-            title="sextant icons"
-          >
-            Sextant icons created by Smashicons - Flaticon
+          <a href="https://github.com/derickkemp/SPhoG">
+            https://github.com/derickkemp/SPhoG
           </a>
         </Md3Typography>
       </Box>

--- a/src/router/routes/About/About.test.jsx
+++ b/src/router/routes/About/About.test.jsx
@@ -7,6 +7,6 @@ import About from "./About";
 describe("About Page", () => {
   it("Rendering the About page should contain its elements", () => {
     renderWithRouter(<About />);
-    expect(screen.getByText("Attributions")).toBeInTheDocument();
+    expect(screen.getByText("SPhoG")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The about page had an unused navigate variable that prevented linting form succeeding.

Also modified the github link to point to the correct project